### PR TITLE
add home as table-of-contents

### DIFF
--- a/home.article
+++ b/home.article
@@ -1,0 +1,12 @@
+Engineering talks from Clever employees
+
+Clever
+@getclever
+https://clever.com
+https://github.com/Clever
+
+* List of talks
+
+The source for all of these talks is available at [[https://github.com/Clever/talks][Clever/talks]].
+
+.link http://go-talks.appspot.com/github.com/Clever/talks/a-year-of-docker/docker.slide A Year of Docker at Clever


### PR DESCRIPTION
This will be available at http://go-talks.appspot.com/github.com/Clever/talks/home.article and can serve as a table of contents.

In the future, it might be nice to set up a redirect from https://talks.clever.com to that URL.
